### PR TITLE
Fix being unable to scroll after opening and closing network modal

### DIFF
--- a/src/components/NetworkSelector/NetworkSelector.js
+++ b/src/components/NetworkSelector/NetworkSelector.js
@@ -9,7 +9,6 @@ import selectorDropdowns from "../../img/ic_selector_dropdowns.svg";
 
 import Select, { components } from "react-select";
 import { find } from "lodash";
-import { useLockBodyScroll } from "react-use";
 
 function getDotColor(network) {
   switch (network) {
@@ -32,8 +31,6 @@ export default function NetworkSelector(props) {
   useEffect(() => {
     setSelectedLabel(label);
   }, [label, networkChanged]);
-
-  useLockBodyScroll(isModalVisible);
 
   function renderOption(option) {
     var optionIcon = require("../../img/" + option.icon);


### PR DESCRIPTION
Occurs on widths < 1380px when clicking collapsed Network Button in nav: 

![image](https://user-images.githubusercontent.com/19278287/185047100-4bb59743-d03f-4170-94e9-13086b1b0c75.png)


