### PR TITLE
Fix bug in menu dropdown when viewport width is at breakpoint

### DIFF
--- a/src/components/Navigation/LinkDropdown/LinkDropdown.styles.js
+++ b/src/components/Navigation/LinkDropdown/LinkDropdown.styles.js
@@ -47,7 +47,7 @@ export const LinkMenu = styled.ul(
   opacity: ${props.open ? 1 : 0};
   pointer-events: ${props.open ? "all" : "none"};
 
-  @media (min-width: 1280px) {
+  @media (min-width: 1281px) {
     display: none;
   }
   @media (max-width: 670px) {


### PR DESCRIPTION
## Motivation

A bug was reported by Billy that the header nav dropdown would not open.  It seems to be a breakpoint issue where if the viewport is set to exactly 1280px, the dropdown display is "none"