### PR TITLE
Fix margin fee value

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -117,6 +117,7 @@ import PageNotFound from "./views/PageNotFound/PageNotFound";
 import useSWR from "swr";
 import LinkDropdown from "./components/Navigation/LinkDropdown/LinkDropdown";
 import Sidebar from "./components/Navigation/Sidebar/Sidebar";
+import { useCumulativeFundingRates } from "./hooks/useCumulativeFundingRates";
 
 if ("ethereum" in window) {
   window.ethereum.autoRefreshOnNetworkChange = false;
@@ -684,6 +685,18 @@ function FullApp() {
   });
 
   const { infoTokens } = useInfoTokens(library, chainId, active, tokenBalances, fundingRateInfo);
+
+  // The "fundingRateInfo" sometimes gets an incorrect value for the cumulative funding rates
+  // when the vault has a nextFundingRate > 0
+  // This corrects the values for the cumulative funding rates
+  const cumulativeFundingRates = useCumulativeFundingRates(chainId, nativeTokenAddress, whitelistedTokenAddresses);
+  if (infoTokens && cumulativeFundingRates) {
+    Object.keys(cumulativeFundingRates).forEach((tokenAddress) => {
+      if (infoTokens[tokenAddress]) {
+        infoTokens[tokenAddress].cumulativeFundingRate = cumulativeFundingRates[tokenAddress];
+      }
+    })
+  }
 
   // Track user wallet connect
   useEffect(() => {

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -110,7 +110,7 @@ export const STABLE_TAX_BASIS_POINTS = 2;
 export const MINT_BURN_FEE_BASIS_POINTS = 18;
 export const SWAP_FEE_BASIS_POINTS = 15;
 export const STABLE_SWAP_FEE_BASIS_POINTS = 3;
-export const MARGIN_FEE_BASIS_POINTS = 10;
+export const MARGIN_FEE_BASIS_POINTS = 3;
 
 export const LIQUIDATION_FEE = expandDecimals(5, USD_DECIMALS);
 

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -110,7 +110,7 @@ export const STABLE_TAX_BASIS_POINTS = 2;
 export const MINT_BURN_FEE_BASIS_POINTS = 18;
 export const SWAP_FEE_BASIS_POINTS = 15;
 export const STABLE_SWAP_FEE_BASIS_POINTS = 3;
-export const MARGIN_FEE_BASIS_POINTS = 3;
+export const MARGIN_FEE_BASIS_POINTS = 10;
 
 export const LIQUIDATION_FEE = expandDecimals(5, USD_DECIMALS);
 

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -7,7 +7,7 @@ import {
 import { toast } from "react-toastify";
 import { useWeb3React, UnsupportedChainIdError } from "@web3-react/core";
 import { useLocalStorage } from "react-use";
-import { ethers } from "ethers";
+import { BigNumber, ethers } from "ethers";
 import { format as formatDateFn } from "date-fns";
 import Token from "./abis/Token.json";
 import _ from "lodash";
@@ -1429,7 +1429,7 @@ export const BSC_RPC_PROVIDERS = [
   "https://bsc-dataseed4.binance.org",
 ];
 
-const RPC_PROVIDERS = {
+export const RPC_PROVIDERS = {
   [ETHEREUM]: ETHEREUM_RPC_PROVIDERS,
   [MAINNET]: BSC_RPC_PROVIDERS,
   [ARBITRUM]: ARBITRUM_RPC_PROVIDERS,

--- a/src/hooks/useCumulativeFundingRates.js
+++ b/src/hooks/useCumulativeFundingRates.js
@@ -1,0 +1,40 @@
+import { useWeb3React } from '@web3-react/core';
+import { ethers } from 'ethers';
+import React, { useEffect } from 'react';
+import { getContract } from '../Addresses';
+import { RPC_PROVIDERS } from '../Helpers';
+import Vault from '../abis/Vault.json';
+
+
+export const useCumulativeFundingRates = (chainId, nativeTokenAddress, whitelistedTokenAddresses) => {
+    const [cumulativeFundingRates, setCumulativeFundingRates] = React.useState(null);
+    const vaultAddress = getContract(chainId, "Vault");
+
+
+    useEffect(() => {
+        handleFetchCumulativeFundingRates();
+    }, [chainId]);
+    
+    async function handleFetchCumulativeFundingRates() {
+        try {
+            const provider = new ethers.providers.JsonRpcProvider(RPC_PROVIDERS[chainId][0]);
+            await provider.ready;
+            const vault = new ethers.Contract(vaultAddress, Vault.abi, provider);
+
+            const rates = {};
+            await Promise.all(
+                whitelistedTokenAddresses.map(async address => {
+                    const tokenAddress = address === ethers.constants.AddressZero ? nativeTokenAddress : address;
+                    const rate = await vault.cumulativeFundingRates(tokenAddress);
+                    rates[address] = rate;
+                })
+            );
+
+            setCumulativeFundingRates(rates);
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
+    return cumulativeFundingRates;
+}


### PR DESCRIPTION
## Motivation
Some users have been reporting that they are being liquidated at the wrong price.  It seems that the frontend calculation for the liquidation price is slightly off

## Changelog
- Fix the margin fee value to match the contracts
- Fetch the correct `cumulativeMarginFee` values from the contract and override the incorrect ones