### PR TITLE
Prevent duplicate notification

### DIFF
--- a/src/Api/index.js
+++ b/src/Api/index.js
@@ -1310,6 +1310,7 @@ export async function callContract(chainId, contract, method, params, opts) {
         hash: res.hash,
         message: opts.successMsg || "Transaction completed!",
       };
+
       opts.setPendingTxns((pendingTxns) => [...pendingTxns, pendingTxn]);
     }
     return res;

--- a/src/App.js
+++ b/src/App.js
@@ -589,11 +589,18 @@ function FullApp() {
   const [pendingTxns, setPendingTxns] = useState([]);
 
   useEffect(() => {
+    const pendingTxnHashes = {};
     const checkPendingTxns = async () => {
       const updatedPendingTxns = [];
       for (let i = 0; i < pendingTxns.length; i++) {
         const pendingTxn = pendingTxns[i];
+        // because the interval is 2 seconds, if the txn takes longer than 2 seconds there
+        // is potential for the interval event que to trigger multiple success or error notifications
+        if (pendingTxnHashes[pendingTxn.hash]) {
+          continue;
+        }
         const receipt = await library.getTransactionReceipt(pendingTxn.hash);
+        pendingTxnHashes[pendingTxn.hash] = true;
         if (receipt) {
           if (receipt.status === 0) {
             const txUrl = getExplorerUrl(chainId) + "tx/" + pendingTxn.hash;


### PR DESCRIPTION
JS ques setInterval events in an event queue. So if the txn took longer than two seconds, pendingTxns has not changed so the interval has not changed but it has queued multiple `checkPendingTxns` calls, resulting in the success or error notification displaying > once.