### PR TITLE
enable swap orders

### DIFF
--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -141,7 +141,7 @@ export const MARKET = "Market";
 export const LIMIT = "Limit";
 export const STOP = "Stop";
 export const LEVERAGE_ORDER_OPTIONS = [MARKET, LIMIT];
-export const SWAP_ORDER_OPTIONS = [MARKET, <ComingSoonTooltip handle={LIMIT} />];
+export const SWAP_ORDER_OPTIONS = [MARKET, LIMIT];
 export const SWAP_OPTIONS = [LONG, SHORT, SWAP];
 export const DEFAULT_SLIPPAGE_AMOUNT = 30;
 export const DEFAULT_HIGHER_SLIPPAGE_AMOUNT = 100;

--- a/src/components/Exchange/SwapBox.js
+++ b/src/components/Exchange/SwapBox.js
@@ -1537,11 +1537,6 @@ export default function SwapBox(props) {
       }
     }
 
-    // Limits not enabled for swaps yet
-    if (opt === SWAP && orderOption === LIMIT) {
-      setOrderOption(MARKET);
-    }
-
     trackAction &&
       trackAction("Swap option changed", {
         option: opt,


### PR DESCRIPTION
- Remove "Coming Soon" from swap limit orders
- Remove temp fix to prevent users from selecting limit orders