### PR TITLE
Disable some tokens in long limit orders

### DIFF
--- a/src/components/Exchange/SwapBox.js
+++ b/src/components/Exchange/SwapBox.js
@@ -1700,16 +1700,25 @@ export default function SwapBox(props) {
     }
     feeBps = feeBasisPoints;
   }
+  const isLongLimitOrder = orderOption === LIMIT && swapOption === LONG;
 
   // If fromToken is in disabled tokens, switch fromToken to WETH
   useEffect(() => {
-    if (orderOption === LIMIT && DISABLED_TOKEN_ADDRESSES.includes(fromTokenAddress)) {
+    if (isLongLimitOrder && DISABLED_TOKEN_ADDRESSES.includes(fromTokenAddress)) {
       setFromTokenAddress(swapOption, nativeTokenAddress);
-    }
-    else if (orderOption === LIMIT && DISABLED_TOKEN_ADDRESSES.includes(toTokenAddress)) {
+    } else if (isLongLimitOrder && DISABLED_TOKEN_ADDRESSES.includes(toTokenAddress)) {
       setToTokenAddress(swapOption, nativeTokenAddress);
     }
-  }, [fromTokenAddress, toTokenAddress, nativeTokenAddress, setFromTokenAddress, setToTokenAddress, swapOption, orderOption]);
+  }, [
+    isLongLimitOrder,
+    fromTokenAddress,
+    toTokenAddress,
+    nativeTokenAddress,
+    setFromTokenAddress,
+    setToTokenAddress,
+    swapOption,
+    orderOption,
+  ]);
 
   if (!fromToken || !toToken) {
     return null;
@@ -1938,7 +1947,7 @@ export default function SwapBox(props) {
                     showMintingCap={false}
                     showTokenImgInDropdown={true}
                     trackAction={trackAction}
-                    disabledTokens={orderOption === LIMIT ? DISABLED_TOKENS : undefined}
+                    disabledTokens={isLongLimitOrder ? DISABLED_TOKENS : undefined}
                   />
                 </div>
               </div>
@@ -2039,7 +2048,7 @@ export default function SwapBox(props) {
                   tokens={toTokens}
                   infoTokens={infoTokens}
                   trackAction={trackAction}
-                  disabledTokens={orderOption === LIMIT ? DISABLED_TOKENS : undefined}
+                  disabledTokens={isLongLimitOrder ? DISABLED_TOKENS : undefined}
                 />
               </div>
             </div>

--- a/src/components/Exchange/SwapBox.js
+++ b/src/components/Exchange/SwapBox.js
@@ -87,6 +87,16 @@ const SWAP_ICONS = {
   [SHORT]: shortImg,
   [SWAP]: swapImg,
 };
+
+const DISABLED_TOKENS = ["LINK", "UNI", "FXS", "BAL", "CRV"];
+const DISABLED_TOKEN_ADDRESSES = [
+  "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4", // LINK
+  "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0", // UNI
+  "0x9d2F299715D94d8A7E6F5eaa8E654E8c74a988A7", // FXS
+  "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8", // BAL
+  "0x11cDb42B0EB46D95f990BeDD4695A6e3fA034978", // CRV
+];
+
 const { AddressZero } = ethers.constants;
 
 function getNextAveragePrice({ size, sizeDelta, hasProfit, delta, nextPrice, isLong }) {
@@ -1691,6 +1701,13 @@ export default function SwapBox(props) {
     feeBps = feeBasisPoints;
   }
 
+  // If fromToken is in disabled tokens, switch fromToken to WETH
+  useEffect(() => {
+    if (orderOption === LIMIT && DISABLED_TOKEN_ADDRESSES.includes(fromTokenAddress)) {
+      setFromTokenAddress(swapOption, nativeTokenAddress);
+    }
+  }, [fromTokenAddress, nativeTokenAddress, setFromTokenAddress, swapOption, orderOption]);
+
   if (!fromToken || !toToken) {
     return null;
   }
@@ -1918,6 +1935,7 @@ export default function SwapBox(props) {
                     showMintingCap={false}
                     showTokenImgInDropdown={true}
                     trackAction={trackAction}
+                    disabledTokens={orderOption === LIMIT ? DISABLED_TOKENS : undefined}
                   />
                 </div>
               </div>
@@ -2018,6 +2036,7 @@ export default function SwapBox(props) {
                   tokens={toTokens}
                   infoTokens={infoTokens}
                   trackAction={trackAction}
+                  disabledTokens={orderOption === LIMIT ? DISABLED_TOKENS : undefined}
                 />
               </div>
             </div>

--- a/src/components/Exchange/SwapBox.js
+++ b/src/components/Exchange/SwapBox.js
@@ -1706,7 +1706,10 @@ export default function SwapBox(props) {
     if (orderOption === LIMIT && DISABLED_TOKEN_ADDRESSES.includes(fromTokenAddress)) {
       setFromTokenAddress(swapOption, nativeTokenAddress);
     }
-  }, [fromTokenAddress, nativeTokenAddress, setFromTokenAddress, swapOption, orderOption]);
+    else if (orderOption === LIMIT && DISABLED_TOKEN_ADDRESSES.includes(toTokenAddress)) {
+      setToTokenAddress(swapOption, nativeTokenAddress);
+    }
+  }, [fromTokenAddress, toTokenAddress, nativeTokenAddress, setFromTokenAddress, setToTokenAddress, swapOption, orderOption]);
 
   if (!fromToken || !toToken) {
     return null;

--- a/src/components/Exchange/TokenSelector.css
+++ b/src/components/Exchange/TokenSelector.css
@@ -77,6 +77,7 @@
 }
 .TokenSelector-token-row.disabled * {
   filter: grayscale(100%);
+  opacity: 0.5;
 }
 .TokenSelector-token-row.disabled:before {
   content: "We have temporarily disabled limit orders for this asset. Check back soon!";

--- a/src/components/Exchange/TokenSelector.css
+++ b/src/components/Exchange/TokenSelector.css
@@ -2,7 +2,7 @@
   width: 20rem;
   margin: 0;
   max-height: 100vh;
-  border: 1px solid var(--cell-highlight)!important;
+  border: 1px solid var(--cell-highlight) !important;
 }
 
 .TokenSelector-token-name {
@@ -72,7 +72,36 @@
   padding: 8px;
   margin-bottom: 8px;
 }
-
+.TokenSelector-token-row.disabled {
+  position: relative;
+}
+.TokenSelector-token-row.disabled * {
+  filter: grayscale(100%);
+}
+.TokenSelector-token-row.disabled:before {
+  content: "We have temporarily disabled limit orders for this asset. Check back soon!";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--cell-stroke);
+  opacity: 0;
+  font-size: 12px;
+  text-align: center;
+  transition: opacity 0.3s ease;
+  z-index: 1;
+}
+.TokenSelector-token-row.disabled:hover {
+  background-color: transparent;
+  cursor: not-allowed;
+}
+.TokenSelector-token-row.disabled:hover:before {
+  opacity: 1;
+}
 .TokenSelector-token-row.TokenSelector-token-input-row {
   padding: 0;
 }
@@ -126,5 +155,8 @@
     width: 30px;
     height: 30px;
     margin-right: 0.5rem;
+  }
+  .TokenSelector-token-row.disabled:before {
+    font-size: 10px;
   }
 }

--- a/src/components/Exchange/TokenSelector.js
+++ b/src/components/Exchange/TokenSelector.js
@@ -26,7 +26,8 @@ export default function TokenSelector(props) {
     showSymbolImage = false,
     showNewCaret = false,
     trackAction,
-    selectedTokenLabel
+    disabledTokens,
+    selectedTokenLabel,
   } = props;
 
   const onSelectToken = (token) => {
@@ -103,14 +104,20 @@ export default function TokenSelector(props) {
             if (balance && info.maxPrice) {
               balanceUsd = balance.mul(info.maxPrice).div(expandDecimals(1, token.decimals));
             }
+            const isDisabled = disabledTokens && disabledTokens.includes(token.symbol);
             return (
               <div
-                className="TokenSelector-token-row"
+                className={cx("TokenSelector-token-row", {
+                  disabled: isDisabled,
+                })}
                 onClick={() => {
-                  onSelectToken(token);
-                  trackAction && trackAction("Button clicked", {
-                    buttonName: `${props.label} Token Selection modal option - ${token.symbol}`,
-                  });
+                  if (!isDisabled) {
+                    onSelectToken(token);
+                    trackAction &&
+                      trackAction("Button clicked", {
+                        buttonName: `${props.label} Token Selection modal option - ${token.symbol}`,
+                      });
+                  }
                 }}
                 key={token.address}
               >
@@ -153,9 +160,10 @@ export default function TokenSelector(props) {
           className="TokenSelector-box"
           onClick={() => {
             setIsModalVisible(true);
-            trackAction && trackAction("Button clicked", {
-              buttonName: `Token selector box`,
-            });
+            trackAction &&
+              trackAction("Button clicked", {
+                buttonName: `Token selector box`,
+              });
           }}
         >
           {tokenInfo.symbol}


### PR DESCRIPTION
- LINK, UNI, FXS, BAL and CRV
- Disable tokens in TokenSelector when `orderOption` === `Limit` and `swapOption` === `Long`
- Add overlay to signify token is disabled in limit order mode
- Switch fromToken or toToken to WETH if disabled token address detected when switching from Market order