### PR TITLE
Fix/advanced view timescale

### DIFF
--- a/src/Api/TradingView/index.js
+++ b/src/Api/TradingView/index.js
@@ -137,6 +137,7 @@ export const dataFeed = {
       console.debug(`[subscribeBars]: id: ${subscribeUID}, resolution: ${resolution}`);
       activeSubscriptions[subscribeUID] = true;
       newPriceEmitter.on('update', (bar) => {
+        console.debug(`[subscribeBars]: found bar on ${subscribeUID}`);
         if (activeSubscriptions[subscribeUID]) {
           onRealtimeCallback({ ...bar, time: bar.time * 1000 })
         }

--- a/src/Api/TradingView/index.js
+++ b/src/Api/TradingView/index.js
@@ -1,5 +1,4 @@
-import {CHART_PERIODS} from "src/Helpers";
-import { roundUpTime } from "src/utils/common";
+import { CHART_PERIODS } from "src/Helpers";
 import { fillGaps, getChartPrices } from "../prices";
 import { newPriceEmitter } from "./newPriceEmitter";
 
@@ -134,13 +133,14 @@ export const dataFeed = {
           onErrorCallback(error);
       }
     },
-    subscribeBars: (_symbolInfo, resolution, onRealtimeCallback, subscribeUID, _onResetCacheNeededCallback) => {
+    subscribeBars: (_symbolInfo, resolution, onRealtimeCallback, subscribeUID, onResetCacheNeededCallback) => {
       console.debug(`[subscribeBars]: id: ${subscribeUID}, resolution: ${resolution}`);
       activeSubscriptions[subscribeUID] = true;
       newPriceEmitter.on('update', (bar) => {
         if (activeSubscriptions[subscribeUID]) {
           onRealtimeCallback({ ...bar, time: bar.time * 1000 })
         }
+        onResetCacheNeededCallback()
       })
     },
     unsubscribeBars: (subscribeUID) => {

--- a/src/Api/TradingView/index.js
+++ b/src/Api/TradingView/index.js
@@ -27,7 +27,7 @@ const config = {
   ]
 };
 
-let activeSubscriptions = {};
+let activeSubscription;
 
 const allSymbols = ["ETH/USD", "BTC/USD", "LINK/USD", "CRV/USD", "BAL/USD", "UNI/USD", "FXS/USD"]
 
@@ -135,17 +135,18 @@ export const dataFeed = {
     },
     subscribeBars: (_symbolInfo, resolution, onRealtimeCallback, subscribeUID, onResetCacheNeededCallback) => {
       console.debug(`[subscribeBars]: id: ${subscribeUID}, resolution: ${resolution}`);
-      activeSubscriptions[subscribeUID] = true;
-      newPriceEmitter.on('update', (bar) => {
+      if (activeSubscription) {
+        newPriceEmitter.removeListener('update', activeSubscription)
+      }
+      const onBarUpdate = (bar) => {
         console.debug(`[subscribeBars]: found bar on ${subscribeUID}`);
-        if (activeSubscriptions[subscribeUID]) {
-          onRealtimeCallback({ ...bar, time: bar.time * 1000 })
-        }
+        onRealtimeCallback({ ...bar, time: bar.time * 1000 })
         onResetCacheNeededCallback()
-      })
+      }
+      activeSubscription = onBarUpdate;
+      newPriceEmitter.on('update', onBarUpdate)
     },
     unsubscribeBars: (subscribeUID) => {
       console.debug(`[unsubscribeBars]: id: ${subscribeUID}`);
-      activeSubscriptions[subscribeUID] = false;
     },
   };

--- a/src/Api/prices.ts
+++ b/src/Api/prices.ts
@@ -60,14 +60,17 @@ export function fillGaps(prices: Price[], periodSeconds: number) {
     }
 
     prevTime = time;
-    
     if (low === 0) {
       newPrices.push({
         ...prices[i],
+        open: newPrices[i - 1].close,
         low: open * 0.9996,
       });
     } else {
-      newPrices.push(prices[i]);
+      newPrices.push(({
+        ...prices[i],
+        open: newPrices[i - 1].close,
+      }));
     }
   }
 
@@ -309,7 +312,7 @@ export const getChartPrices = async (chainId: ChainId, symbol: TokenSymbol, peri
     console.warn(ex);
     console.warn("Switching to v1 stats data");
     try {
-      return await getChartPricesFromStats(chainId, symbol, period, range);
+      return await getChartPricesFromStatsV1(chainId, symbol, period, range);
     } catch (ex) {
       console.warn("Switching to graph chainlink data");
       try {

--- a/src/components/Exchange/ExchangeAdvancedTVChart/index.js
+++ b/src/components/Exchange/ExchangeAdvancedTVChart/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import cx from "classnames";
 import { widget } from "@mycelium-swaps-interface/charting_library";
 import { dataFeed, supportedResolutions } from "../../../Api/TradingView";
@@ -27,14 +27,6 @@ const convertLightweightChartPeriod = (period) => {
     default:
       return supportedResolutions[4]; // 240
   }
-};
-
-const TIMEFRAME = {
-  "5m": "210",
-  "15m": "840",
-  "1h": "1680",
-  "4h": "7D",
-  "1d": "30D",
 };
 
 const DEFAULT_COLOURS = {
@@ -168,7 +160,6 @@ export default function ExchangeAdvancedTVChart(props) {
     if (tvWidget && priceData && showChart && priceData.length >= 1) {
       if (tvWidget.activeChart().dataReady()) {
         const lastBar = priceData[priceData.length - 1];
-        console.log("emitting update")
         newPriceEmitter.emit('update', lastBar)
       }
     }

--- a/src/components/Exchange/ExchangeAdvancedTVChart/index.js
+++ b/src/components/Exchange/ExchangeAdvancedTVChart/index.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from "react";
 import cx from "classnames";
 import { widget } from "@mycelium-swaps-interface/charting_library";
 import { dataFeed, supportedResolutions } from "../../../Api/TradingView";
-import {newPriceEmitter} from "src/Api/TradingView/newPriceEmitter";
+import { newPriceEmitter } from "src/Api/TradingView/newPriceEmitter";
 
 const getLanguageFromURL = () => {
   const regex = new RegExp("[\\?&]lang=([^&#]*)");
@@ -130,6 +130,12 @@ export default function ExchangeAdvancedTVChart(props) {
       tvWidget.onChartReady(() => {
         setShowChart(true);
         setTvWidget(tvWidget);
+
+        tvWidget.activeChart().onDataLoaded().subscribe(
+          null,
+          () => console.log('New bars laoded'),
+          true
+        )
       });
     } catch (error) {
       console.error(error);
@@ -158,9 +164,13 @@ export default function ExchangeAdvancedTVChart(props) {
   }, [tvWidget, period, chartToken?.symbol])
 
   useEffect(() => {
+
     if (tvWidget && priceData && showChart && priceData.length >= 1) {
-      const lastBar = priceData[priceData.length - 1];
-      newPriceEmitter.emit('update', lastBar)
+      if (tvWidget.activeChart().dataReady()) {
+        const lastBar = priceData[priceData.length - 1];
+        console.log("emitting update")
+        newPriceEmitter.emit('update', lastBar)
+      }
     }
   }, [tvWidget, showChart, priceData])
 


### PR DESCRIPTION
Attempt to fix advanced trading view timescale. 
- Kurtis was having issues where it was missing a whole bunch of data, fixed by ensuring that the request returns > countback or it returns noData = true, previously was just fetching 1000 candle results and returning noData. This seemed to work but trading view is doing something funky under the hood with countback
- Some users were having issues with timescale, I am just guessing that this was because old subscriptions increasing the time https://discord.com/channels/808906099172442122/808906099172442125/1047898301846003802, I removed the roundUp time to see if this fixes the issue as well as added an activeSubscriptions object which tracks open subs
- re-using fillGaps instead of has_empty_bars to remove `time order violation` errors https://github.com/tradingview/charting_library/issues/1930