### PR TITLE
Disable certain tokens

### DIFF
--- a/src/components/Exchange/SwapBox.js
+++ b/src/components/Exchange/SwapBox.js
@@ -87,6 +87,8 @@ const SWAP_ICONS = {
   [SHORT]: shortImg,
   [SWAP]: swapImg,
 };
+const DISABLED_COLLATERAL_TOKENS = ["FXS", "CRV", "UNI", "BAL", "FRAX"];
+
 const { AddressZero } = ethers.constants;
 
 function getNextAveragePrice({ size, sizeDelta, hasProfit, delta, nextPrice, isLong }) {
@@ -244,13 +246,15 @@ export default function SwapBox(props) {
 
   const whitelistedTokens = getWhitelistedTokens(chainId);
   const tokens = getTokens(chainId);
-  const fromTokens = tokens;
+  const enabledTokens = tokens.filter((token) => token.isEnabledForTrading);
+  const fromTokens = enabledTokens;
   const stableTokens = tokens.filter((token) => token.isStable);
   const indexTokens = whitelistedTokens.filter((token) => !token.isStable && !token.isWrapped);
-  const shortableTokens = indexTokens.filter((token) => token.isShortable);
+  const enabledIndexTokens = whitelistedTokens.filter((token) => token.isEnabledForTrading);
+  const shortableTokens = indexTokens.filter((token) => token.isShortable && token.isEnabledForTrading);
   let toTokens = tokens;
   if (isLong) {
-    toTokens = indexTokens;
+    toTokens = enabledIndexTokens;
   }
   if (isShort) {
     toTokens = shortableTokens;

--- a/src/components/Mlp/MlpSwap.js
+++ b/src/components/Mlp/MlpSwap.js
@@ -111,6 +111,7 @@ export default function MlpSwap(props) {
   // const chainName = getChainName(chainId)
   const tokens = getTokens(chainId);
   const whitelistedTokens = getWhitelistedTokens(chainId);
+  const enabledWhitelistedTokens = whitelistedTokens.filter((token) => token.isEnabledForTrading);
   const tokenList = whitelistedTokens.filter((t) => !t.isWrapped);
   const [swapValue, setSwapValue] = useState("");
   const [mlpValue, setMlpValue] = useState("");
@@ -901,7 +902,7 @@ export default function MlpSwap(props) {
                 chainId={chainId}
                 tokenAddress={swapTokenAddress}
                 onSelectToken={onSelectSwapToken}
-                tokens={whitelistedTokens}
+                tokens={enabledWhitelistedTokens}
                 infoTokens={infoTokens}
                 className="MlpSwap-from-token"
                 showSymbolImage={true}

--- a/src/data/Tokens.js
+++ b/src/data/Tokens.js
@@ -78,6 +78,7 @@ const TOKENS = {
       isNative: true,
       isShortable: true,
       imageUrl: "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+      isEnabledForTrading: true,
     },
     {
       name: "Wrapped Ethereum",
@@ -87,6 +88,7 @@ const TOKENS = {
       isWrapped: true,
       baseSymbol: "ETH",
       imageUrl: "https://assets.coingecko.com/coins/images/2518/thumb/weth.png?1628852295",
+      isEnabledForTrading: true,
     },
     {
       name: "Bitcoin (WBTC)",
@@ -95,6 +97,7 @@ const TOKENS = {
       address: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
       isShortable: true,
       imageUrl: "https://assets.coingecko.com/coins/images/7598/thumb/wrapped_bitcoin_wbtc.png?1548822744",
+      isEnabledForTrading: true,
     },
     {
       name: "Chainlink",
@@ -104,6 +107,7 @@ const TOKENS = {
       isStable: false,
       isShortable: true,
       imageUrl: "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1547034700",
+      isEnabledForTrading: true,
     },
     {
       name: "Uniswap",
@@ -121,6 +125,7 @@ const TOKENS = {
       address: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       isStable: true,
       imageUrl: "https://assets.coingecko.com/coins/images/6319/thumb/USD_Coin_icon.png?1547042389",
+      isEnabledForTrading: true,
     },
     {
       name: "Tether",
@@ -129,6 +134,7 @@ const TOKENS = {
       address: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
       isStable: true,
       imageUrl: "https://assets.coingecko.com/coins/images/325/thumb/Tether-logo.png?1598003707",
+      isEnabledForTrading: true,
     },
     {
       name: "Dai",
@@ -137,6 +143,7 @@ const TOKENS = {
       address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
       isStable: true,
       imageUrl: "https://assets.coingecko.com/coins/images/9956/thumb/4943.png?1636636734",
+      isEnabledForTrading: true,
     },
     {
       name: "Frax",


### PR DESCRIPTION
**Removes the ability to:**

- open new FXS, CRV, UNI, BAL, or FRAX leveraged positions
- use FXS, CRV, UNI, BAL, or FRAX as collateral for margin leveraged positions
- execute swaps where FXS, CRV, UNI, BAL, or FRAX are the tokens being SOLD by the user
- buy MLP, using FXS, CRV, UNI, BAL, or FRAX