### PR TITLE
Add "cancel all" button to orders

### DIFF
--- a/src/Api/index.js
+++ b/src/Api/index.js
@@ -33,7 +33,7 @@ import {
   USD_DECIMALS,
   ETH_DECIMALS,
   ARBITRUM_GOERLI,
-  SECONDS_PER_YEAR
+  SECONDS_PER_YEAR,
 } from "../Helpers";
 import { getTokenBySymbol } from "../data/Tokens";
 
@@ -125,16 +125,22 @@ export function useSpreadCaptureVolume(chainId) {
   const [res, setRes] = useState(undefined);
 
   useEffect(() => {
-    getMycGraphClient(chainId).query({ query }).then((res) => {
-      const totalMMFees = res.data.volumeStats.reduce((sum, stat) => sum
-        .add(MM_FEE_MULTIPLIER.mul(stat.mint))
-        .add(MM_FEE_MULTIPLIER.mul(stat.burn))
-        .add(MM_FEE_MULTIPLIER.mul(stat.margin))
-        .add(MM_FEE_MULTIPLIER.mul(stat.liquidation))
-        .add(MM_SWAPS_FEE_MULTIPLIER.mul(stat.swap))
-      , bigNumberify(0));
-      setRes(totalMMFees.div(expandDecimals(1, FEE_MULTIPLIER_BASIS_POINTS)))
-    }).catch(console.warn);
+    getMycGraphClient(chainId)
+      .query({ query })
+      .then((res) => {
+        const totalMMFees = res.data.volumeStats.reduce(
+          (sum, stat) =>
+            sum
+              .add(MM_FEE_MULTIPLIER.mul(stat.mint))
+              .add(MM_FEE_MULTIPLIER.mul(stat.burn))
+              .add(MM_FEE_MULTIPLIER.mul(stat.margin))
+              .add(MM_FEE_MULTIPLIER.mul(stat.liquidation))
+              .add(MM_SWAPS_FEE_MULTIPLIER.mul(stat.swap)),
+          bigNumberify(0)
+        );
+        setRes(totalMMFees.div(expandDecimals(1, FEE_MULTIPLIER_BASIS_POINTS)));
+      })
+      .catch(console.warn);
   }, [setRes, query, chainId]);
 
   return res;
@@ -930,25 +936,37 @@ export async function createDecreaseOrder(
   return callContract(chainId, contract, "createDecreaseOrder", params, opts);
 }
 
-export async function cancelSwapOrder(chainId, orderBookAddress, library, index, opts) {
+export async function cancelSwapOrder(chainId, library, index, opts) {
   const params = [index];
   const method = "cancelSwapOrder";
+  const orderBookAddress = getContract(chainId, "OrderBook");
   const contract = new ethers.Contract(orderBookAddress, OrderBook.abi, library.getSigner());
 
   return callContract(chainId, contract, method, params, opts);
 }
 
-export async function cancelDecreaseOrder(chainId, orderBookAddress, library, index, opts) {
+export async function cancelDecreaseOrder(chainId, library, index, opts) {
   const params = [index];
   const method = "cancelDecreaseOrder";
+  const orderBookAddress = getContract(chainId, "OrderBook");
   const contract = new ethers.Contract(orderBookAddress, OrderBook.abi, library.getSigner());
 
   return callContract(chainId, contract, method, params, opts);
 }
 
-export async function cancelIncreaseOrder(chainId, orderBookAddress, library, index, opts) {
+export async function cancelIncreaseOrder(chainId, library, index, opts) {
   const params = [index];
   const method = "cancelIncreaseOrder";
+  const orderBookAddress = getContract(chainId, "OrderBook");
+  const contract = new ethers.Contract(orderBookAddress, OrderBook.abi, library.getSigner());
+
+  return callContract(chainId, contract, method, params, opts);
+}
+
+export async function cancelMultipleOrders(chainId, library, swapIndexes, increaseIndexes, decreaseIndexes, opts) {
+  const params = [swapIndexes, increaseIndexes, decreaseIndexes];
+  const method = "cancelMultiple";
+  const orderBookAddress = getContract(chainId, "OrderBook");
   const contract = new ethers.Contract(orderBookAddress, OrderBook.abi, library.getSigner());
 
   return callContract(chainId, contract, method, params, opts);
@@ -1070,31 +1088,45 @@ export function useStakingApr(mycPrice, ethPrice) {
 
   // apr is annualised rewards (USD value) / total staked (USD value) * 100
   const { data: tokensPerInterval } = useSWR(
-    [`useStakingApr:tokensPerInterval:${ARBITRUM}`, ARBITRUM, getContract(ARBITRUM, "MYCStakingRewards"), "tokensPerInterval"],
+    [
+      `useStakingApr:tokensPerInterval:${ARBITRUM}`,
+      ARBITRUM,
+      getContract(ARBITRUM, "MYCStakingRewards"),
+      "tokensPerInterval",
+    ],
     {
       fetcher: fetcher(undefined, RewardsTracker),
     }
   );
 
-  const mycTokenAddress = getContract(ARBITRUM, 'MYC');
+  const mycTokenAddress = getContract(ARBITRUM, "MYC");
   const { data: mycDeposited } = useSWR(
-    [`useStakingApr:totalDepositSupply(MYC):${ARBITRUM}`, ARBITRUM, getContract(ARBITRUM, "MYCStakingRewards"), "totalDepositSupply"],
+    [
+      `useStakingApr:totalDepositSupply(MYC):${ARBITRUM}`,
+      ARBITRUM,
+      getContract(ARBITRUM, "MYCStakingRewards"),
+      "totalDepositSupply",
+    ],
     {
-      fetcher: fetcher(undefined, RewardsTracker, mycTokenAddress)
+      fetcher: fetcher(undefined, RewardsTracker, mycTokenAddress),
     }
   );
 
-  const esMycTokenAddress = getContract(ARBITRUM, 'ES_MYC');
+  const esMycTokenAddress = getContract(ARBITRUM, "ES_MYC");
   const { data: esMycDeposited } = useSWR(
-    [`useStakingApr:totalDepositSupply(esMYC):${ARBITRUM}`, ARBITRUM, getContract(ARBITRUM, "MYCStakingRewards"), "totalDepositSupply"],
+    [
+      `useStakingApr:totalDepositSupply(esMYC):${ARBITRUM}`,
+      ARBITRUM,
+      getContract(ARBITRUM, "MYCStakingRewards"),
+      "totalDepositSupply",
+    ],
     {
-      fetcher: fetcher(undefined, RewardsTracker, esMycTokenAddress)
+      fetcher: fetcher(undefined, RewardsTracker, esMycTokenAddress),
     }
   );
 
   useEffect(() => {
-    if(ethPrice?.gt(0) && mycPrice?.gt(0) && tokensPerInterval && mycDeposited && esMycDeposited) {
-
+    if (ethPrice?.gt(0) && mycPrice?.gt(0) && tokensPerInterval && mycDeposited && esMycDeposited) {
       const tokensPerYear = tokensPerInterval.mul(SECONDS_PER_YEAR);
       const annualRewardsUsd = tokensPerYear.mul(ethPrice);
 
@@ -1104,7 +1136,7 @@ export function useStakingApr(mycPrice, ethPrice) {
       const aprPrecision = 10;
       const apr = annualRewardsUsd.mul(expandDecimals(1, aprPrecision)).div(totalDepositsUsd);
 
-      const formattedApr = apr.toNumber() / (10 ** aprPrecision) * 100;
+      const formattedApr = (apr.toNumber() / 10 ** aprPrecision) * 100;
       setStakingApr(formattedApr.toFixed(2));
     }
   }, [ethPrice, mycPrice, tokensPerInterval, mycDeposited, esMycDeposited]);

--- a/src/components/Exchange/OrdersList.css
+++ b/src/components/Exchange/OrdersList.css
@@ -87,6 +87,12 @@ button.Orders-list-action:hover {
   width: 22rem;
 }
 
+.cancelAllButton {
+  text-decoration: underline;
+  color: var(--action-active);
+  cursor: pointer;
+}
+
 @media (max-width: 1000px) {
   .Orders-list.small {
     display: block;


### PR DESCRIPTION
# Changelog

- Add "Cancel All" button in top row of orders


Note: this removes the more mobile friendly version of the orders list in order to add the Cancel All button.  If a suitable location for the button can be found in this version of the list, it can be re-enabled by uncommenting the relevant code and re-adding the "large" and "small" classes where applicable